### PR TITLE
add synthesis node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Research Agent
+
+A LangGraph-based research orchestration agent that decomposes a topic into parallel searches across arXiv, Hacker News, and Semantic Scholar, then synthesizes the results into a structured report.
+
+## Architecture
+
+```
+START
+  └─► planner          — Gemini generates N focused search tasks
+        └─► [fan-out]
+              ├─► research_node  — arXiv + HN + Semantic Scholar (parallel)
+              ├─► research_node  — arXiv + HN + Semantic Scholar (parallel)
+              └─► research_node  — arXiv + HN + Semantic Scholar (parallel)
+                    └─► synthesizer  — Gemini synthesizes all results
+                              └─► END
+```
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 2. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+| Variable         | Required | Description                        |
+|------------------|----------|------------------------------------|
+| `GOOGLE_API_KEY` | Yes      | Google AI Studio or Vertex API key |
+| `TAVILY_API_KEY` | Yes      | Tavily search API key              |
+
+### 3. Run
+
+```bash
+python -m src.run
+```
+
+## Configuration
+
+Tune agent behaviour without code changes using `AGENT_`-prefixed environment variables:
+
+| Variable             | Default            | Description                                        |
+|----------------------|--------------------|----------------------------------------------------|
+| `AGENT_MODEL`        | `gemini-2.5-flash` | Gemini model for planner & synthesizer             |
+| `AGENT_TEMPERATURE`  | `0.0`              | LLM temperature                                    |
+| `AGENT_NUM_TASKS`    | `3`                | Number of parallel research tasks                  |
+| `AGENT_SEARCH_DEPTH` | `basic`            | Tavily search depth (`basic` or `advanced`)        |
+| `AGENT_MAX_RESULTS`  | `3`                | Max Tavily results per query                       |
+
+## Project Structure
+
+```
+src/
+├── run.py                          # Entry point
+└── agent/
+    ├── config.py                   # Centralised settings (pydantic-settings)
+    ├── logging_config.py           # Shared logger factory
+    ├── state.py                    # LangGraph AgentState
+    ├── graph.py                    # Graph definition and fan-out logic
+    ├── nodes/
+    │   ├── planner/
+    │   │   ├── planner_node.py     # Generates research tasks via LLM
+    │   │   └── response_schema.py  # ResearchTask / ResearchPlan schemas
+    │   ├── researcher/
+    │   │   └── research_node.py    # Executes searches across all sources
+    │   └── synthesizer/
+    │       └── synthesizer_node.py # Synthesizes results into a report
+    └── tools/
+        ├── arxiv_search_tool.py
+        ├── hackernews_search_tool.py
+        ├── semantic_scholar_tool.py
+        └── tavily_web_search_tool.py
+```

--- a/src/agent/config.py
+++ b/src/agent/config.py
@@ -1,0 +1,19 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    # LLM
+    model: str = "gemini-2.5-flash"
+    temperature: float = 0.0
+
+    # Planner
+    num_tasks: int = 3
+
+    # Tavily search
+    search_depth: str = "basic"
+    max_results: int = 3
+
+    model_config = {"env_prefix": "AGENT_"}
+
+
+settings = Settings()

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -1,30 +1,25 @@
 from langgraph.graph import StateGraph, START, END
+from langgraph.types import Send
 from src.agent.state import AgentState
 from src.agent.nodes.planner.planner_node import planner_node
 from src.agent.nodes.researcher.research_node import research_node
-from langgraph.types import Send # syntax: Send("target_node", payload)
+from src.agent.nodes.synthesizer.synthesizer_node import synthesizer_node
 
 
 builder = StateGraph(AgentState)
 
-# implement fan out strategy: the planner node outputs List[ResearchTask] 
-# we want each task to be handled in parallel by the next node
 
 def fan_out(state: AgentState):
-    send_list = []
-    for task in state["plan"]:
-        send_list.append(Send("research_node", task))
-    
-    return send_list # need to return a list of send objects
+    return [Send("research_node", task) for task in state["plan"]]
 
 
 builder.add_node("planner", planner_node)
 builder.add_node("research_node", research_node)
-
+builder.add_node("synthesizer", synthesizer_node)
 
 builder.add_edge(START, "planner")
 builder.add_conditional_edges("planner", fan_out)
-builder.add_edge("research_node", END)
+builder.add_edge("research_node", "synthesizer")
+builder.add_edge("synthesizer", END)
 
-# Export for LangGraph Studio / Deployment
 graph = builder.compile()

--- a/src/agent/logging_config.py
+++ b/src/agent/logging_config.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s [%(levelname)-8s] %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        ))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/src/agent/nodes/planner/planner_node.py
+++ b/src/agent/nodes/planner/planner_node.py
@@ -1,37 +1,32 @@
-# this node translates an input of interested to search queries
-# we need to use pdantic .with_structured_output to force a set response schema
-# LEARN: how does with_structured_output work under the hood? 
-
 from langchain_google_genai import ChatGoogleGenerativeAI
-from src.agent.state import AgentState  # Assuming this exists from earlier
+from src.agent.state import AgentState
+from src.agent.config import settings
+from src.agent.logging_config import get_logger
 from .response_schema import ResearchPlan
 
-# Initialize Gemini
-llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=0)
+logger = get_logger(__name__)
 
-# Bind the Pydantic model to the LLM
+llm = ChatGoogleGenerativeAI(model=settings.model, temperature=settings.temperature)
 planner_llm = llm.with_structured_output(ResearchPlan)
 
-def planner_node(state: AgentState):
+
+def planner_node(state: AgentState) -> dict:
     """Takes a single interest and generates a structured research plan."""
-    
-    # Grab the interest from the graph state
-    interest = state.get("interest", "AI agents") 
-    
+    interest = state.get("interest", "AI agents")
+    logger.info("Planning research for: %s", interest)
+
     prompt = f"""
-    You are a Senior Research Architect. 
+    You are a Senior Research Architect.
     The user is interested in: {interest}
-    
-    Your goal: Create 3 specific, distinct search tasks to find the newest and 
-    most impactful research from the last 30 days. 
+
+    Your goal: Create {settings.num_tasks} specific, distinct search tasks to find the newest and
+    most impactful research from the last 30 days.
     Focus on finding breakthroughs that have practical code implementations.
 
     For the 'source' field, set exactly one task to 'semantic_scholar' for deep citation analysis.
     Set the other tasks to 'arxiv' or 'hackernews'.
     """
-    
-    # The LLM returns a ResearchPlan object (thanks to Pydantic)
+
     plan = planner_llm.invoke(prompt)
-    
-    # We return a dictionary that updates the 'plan' key in our Graph State
+    logger.info("Generated %d research tasks", len(plan.tasks))
     return {"plan": plan.tasks}

--- a/src/agent/nodes/researcher/research_node.py
+++ b/src/agent/nodes/researcher/research_node.py
@@ -1,25 +1,26 @@
-# from src.agent.tools.tavily_web_search_tool import search_web # Deactivated for now
 from src.agent.tools.arxiv_search_tool import search_arxiv
 from src.agent.tools.hackernews_search_tool import search_hackernews
 from src.agent.tools.semantic_scholar_tool import search_semantic_scholar
-from src.agent.state import ResearchTask
+from src.agent.nodes.planner.response_schema import ResearchTask
+from src.agent.logging_config import get_logger
 
-def research_node(state: ResearchTask):
-    # state is the Pydantic ResearchTask object from the Send() command
+logger = get_logger(__name__)
+
+
+def research_node(state: ResearchTask) -> dict:
+    """Executes a single search task and returns structured results."""
     query = state.query
     source = state.source
-    
-    print(f"Researching ({source}): {query}")
-    
-    # Always run fast/open tools
+    logger.info("Researching (%s): %s", source, query)
+
     arxiv_results = search_arxiv(query)
     hn_results = search_hackernews(query)
-    
-    # Only run Semantic Scholar if explicitly requested (to avoid rate limits)
     ss_results = search_semantic_scholar(query) if source == "semantic_scholar" else []
-    
+
     results = arxiv_results + hn_results + ss_results
-        
-    print(f"   - Found {len(results)} total results ({len(arxiv_results)} Arxiv, {len(hn_results)} HN, {len(ss_results)} Scholar)")
-    
+    logger.info(
+        "Found %d total results (%d Arxiv, %d HN, %d Scholar)",
+        len(results), len(arxiv_results), len(hn_results), len(ss_results),
+    )
+
     return {"research_results": [{"query": state.query, "data": results}]}

--- a/src/agent/nodes/synthesizer/synthesizer_node.py
+++ b/src/agent/nodes/synthesizer/synthesizer_node.py
@@ -1,0 +1,44 @@
+from langchain_google_genai import ChatGoogleGenerativeAI
+from src.agent.state import AgentState
+from src.agent.config import settings
+from src.agent.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+llm = ChatGoogleGenerativeAI(model=settings.model, temperature=settings.temperature)
+
+
+def synthesizer_node(state: AgentState) -> dict:
+    """Synthesizes parallel research results into a structured report."""
+    interest = state.get("interest", "")
+    research_results = state.get("research_results", [])
+
+    logger.info("Synthesizing %d research results", len(research_results))
+
+    sources_text = ""
+    for entry in research_results:
+        sources_text += f"\n### Query: {entry['query']}\n"
+        for source in entry.get("data", []):
+            snippet = source.get("content", "")[:400]
+            sources_text += f"- **{source.get('title')}** ({source.get('url')})\n  {snippet}\n"
+
+    prompt = f"""You are a research analyst. The user is interested in: {interest}
+
+Based on the following gathered sources, produce a concise synthesis report.
+
+{sources_text}
+
+Structure your report as:
+## Key Findings
+(3-5 bullet points highlighting the most important developments)
+
+## Notable Sources
+(2-3 sources most worth following up on, with a one-line reason each)
+
+## Summary
+(1-2 paragraph overview)
+"""
+
+    response = llm.invoke(prompt)
+    logger.info("Synthesis complete")
+    return {"synthesis": response.content}

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -13,4 +13,4 @@ class AgentState(TypedDict, total=False):
     plan: List[ResearchTask]
 
     research_results: Annotated[List[dict], operator.add]
-
+    synthesis: str

--- a/src/agent/tools/tavily_web_search_tool.py
+++ b/src/agent/tools/tavily_web_search_tool.py
@@ -1,29 +1,37 @@
 import os
 from tavily import TavilyClient
+from src.agent.config import settings
+from src.agent.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 tavily_client = TavilyClient(api_key=os.getenv("TAVILY_API_KEY"))
 
-def search_web(query: str):
+
+def search_web(query: str) -> list:
     try:
-        # time_range options: "d" (day), "w" (week), "m" (month), "y" (year)
-        response = tavily_client.search(query, max_results=3, search_depth="basic", time_range="w")
+        response = tavily_client.search(
+            query,
+            max_results=settings.max_results,
+            search_depth=settings.search_depth,
+            time_range="w",
+        )
         raw_results = response.get("results", [])
 
         if not raw_results:
-            print(f"No results found for: {query}")
+            logger.warning("No results found for: %s", query)
             return []
 
-        formatted = []
-        for res in raw_results:
+        return [
+            {
+                "title": res.get("title", "Untitled"),
+                "url": res.get("url", "#"),
+                "content": res.get("content", "No content found."),
+            }
+            for res in raw_results
+            if isinstance(res, dict)
+        ]
 
-            if isinstance(res, dict):
-                formatted.append({
-                    "title": res.get("title", "Untitled"),
-                    "url": res.get("url", "#"),
-                    "content": res.get("content", "No content found."),
-                })
-        return formatted
-        
     except Exception as e:
-        print(f" Tavily Error: {e}")
+        logger.error("Tavily search failed for '%s': %s", query, e)
         return []

--- a/src/run.py
+++ b/src/run.py
@@ -1,48 +1,42 @@
 import os
 from dotenv import load_dotenv
 from src.agent.graph import graph
+from src.agent.logging_config import get_logger
 
 load_dotenv()
 
+logger = get_logger(__name__)
+
+
 def main():
     initial_input = {"interest": "DeepSeek R1 vs Gemini 2.0 Flash"}
-    print("--- Starting Local Workflow ---\n")
+    logger.info("Starting research agent")
 
-    # We use this variable to store the final state emitted by the graph
     final_output = None
 
     for event in graph.stream(initial_input, stream_mode="values"):
-        # 'values' mode is better for final inspection because 
-        # it always gives you a snapshot of the ENTIRE state.
         final_output = event
-        
-        # Optional: Print progress updates as they happen
+
         if "plan" in event and "research_results" not in event:
-             print(f"Plan generated with {len(event['plan'])} tasks...")
+            logger.info("Plan ready — %d tasks queued", len(event["plan"]))
 
-    # --- FINAL PRINTING ---
-    print("\n" + "="*50)
-    print("FINAL RESEARCH REPORT")
-    print("="*50)
+    print("\n" + "=" * 60)
+    print("RESEARCH REPORT")
+    print("=" * 60)
 
-    # Access the aggregated list from your Reducer
-    results = final_output.get("research_results", [])
-    
-    if not results:
-        print("No research results were collected.")
-        # Debugging: Print available keys to help identify mismatches
-        print(f"DEBUG: Final State Keys: {list(final_output.keys())}")
+    synthesis = final_output.get("synthesis") if final_output else None
+
+    if synthesis:
+        print(synthesis)
     else:
-        for i, entry in enumerate(results, 1):
-            print(f"\nTASK {i}: {entry.get('query')}")
-            print("-" * 30)
+        logger.warning("No synthesis produced. Raw results below.")
+        for entry in (final_output or {}).get("research_results", []):
+            print(f"\n[{entry.get('query')}]")
             for source in entry.get("data", []):
-                print(f"• {source.get('title')}")
-                print(f"  URL: {source.get('url')}")
-                # Print a small snippet of the content
-                snippet = source.get('content', '')[:150] + "..."
-                print(f"  Snippet: {snippet}\n")
+                print(f"  • {source.get('title')} — {source.get('url')}")
 
-                
+    print("=" * 60)
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Adds a `synthesizer` node that takes all parallel research results and calls Gemini to produce a structured markdown report (Key Findings, Notable Sources, Summary)
- Centralises all hardcoded values into `src/agent/config.py` using pydantic-settings with `AGENT_` env prefix
- Replaces all `print()` calls with structured logging via a shared `get_logger()` factory (still visible in console)
- Adds `README.md` with setup instructions, env vars table, and architecture diagram

## Graph change
`research_node → synthesizer → END` (previously `research_node → END`)

## Test plan
- [ ] Set `GOOGLE_API_KEY` and `TAVILY_API_KEY` in `.env`
- [ ] Run `python -m src.run` and verify timestamped logs appear in console
- [ ] Confirm final output is a synthesized markdown report, not raw URLs
- [ ] Override a setting (e.g. `AGENT_MAX_RESULTS=5`) and verify it is respected