### PR TITLE
Add parallel evaluation pipeline

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -1,25 +1,49 @@
 from langgraph.graph import StateGraph, START, END
 from langgraph.types import Send
+
 from src.agent.state import AgentState
 from src.agent.nodes.planner.planner_node import planner_node
 from src.agent.nodes.researcher.research_node import research_node
-from src.agent.nodes.synthesizer.synthesizer_node import synthesizer_node
+from src.agent.nodes.researcher.prepare_candidates_node import prepare_candidates_node
+from src.agent.nodes.evaluator.evaluate_paper_node import evaluate_paper_node
+from src.agent.nodes.evaluator.aggregator_node import aggregator_node
 
 
 builder = StateGraph(AgentState)
 
 
+# ── Fan-out: one research_node per planned task ────────────────────────────────
 def fan_out(state: AgentState):
     return [Send("research_node", task) for task in state["plan"]]
 
 
+# ── Map step: one evaluate_paper_node per candidate paper ─────────────────────
+def map_papers(state: AgentState):
+    return [Send("evaluate_paper_node", {"paper": p}) for p in state.get("candidate_papers", [])]
+
+
+# ── Nodes ─────────────────────────────────────────────────────────────────────
 builder.add_node("planner", planner_node)
 builder.add_node("research_node", research_node)
-builder.add_node("synthesizer", synthesizer_node)
+builder.add_node("prepare_candidates", prepare_candidates_node)
+builder.add_node("evaluate_paper_node", evaluate_paper_node)
+builder.add_node("aggregator", aggregator_node)
 
+# ── Edges ─────────────────────────────────────────────────────────────────────
+#
+#  START
+#    └──► planner
+#           └──► [fan_out] ──► research_node (× N, parallel)
+#                                └──► prepare_candidates   (fan-in barrier)
+#                                       └──► [map_papers] ──► evaluate_paper_node (× M, parallel)
+#                                                               └──► aggregator    (fan-in barrier)
+#                                                                      └──► END
+#
 builder.add_edge(START, "planner")
 builder.add_conditional_edges("planner", fan_out)
-builder.add_edge("research_node", "synthesizer")
-builder.add_edge("synthesizer", END)
+builder.add_edge("research_node", "prepare_candidates")
+builder.add_conditional_edges("prepare_candidates", map_papers)
+builder.add_edge("evaluate_paper_node", "aggregator")
+builder.add_edge("aggregator", END)
 
 graph = builder.compile()

--- a/src/agent/nodes/evaluator/aggregator_node.py
+++ b/src/agent/nodes/evaluator/aggregator_node.py
@@ -1,0 +1,24 @@
+from src.agent.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def aggregator_node(state: dict) -> dict:
+    """Reduce step: sorts all evaluated papers by weighted score and filters to digest-worthy entries.
+
+    Runs once after all parallel evaluate_paper_node instances complete.
+    Returns {"digest": [...]} with papers sorted descending by weighted_score,
+    limited to those where include_in_digest is True.
+    """
+    evaluated = state.get("evaluated_papers", [])
+    logger.info("Aggregating %d evaluated papers", len(evaluated))
+
+    included = [p for p in evaluated if p.include_in_digest]
+    ranked = sorted(included, key=lambda p: p.weighted_score, reverse=True)
+
+    logger.info(
+        "%d / %d papers qualify for digest",
+        len(ranked),
+        len(evaluated),
+    )
+    return {"digest": ranked}

--- a/src/agent/nodes/evaluator/evaluate_paper_node.py
+++ b/src/agent/nodes/evaluator/evaluate_paper_node.py
@@ -1,0 +1,69 @@
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+from src.agent.nodes.evaluator.evaluation_schema import EvaluationResult
+from src.agent.config import settings
+from src.agent.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_llm = ChatGoogleGenerativeAI(model=settings.model, temperature=settings.temperature)
+_evaluator_llm = _llm.with_structured_output(EvaluationResult)
+
+# Weights must sum to 1.0
+_WEIGHTS = {
+    "novelty": 0.25,
+    "clinical_efficacy": 0.30,
+    "source_authority": 0.25,
+    "trending_signal": 0.20,
+}
+
+
+def evaluate_paper_node(state: dict) -> dict:
+    """Evaluates a single paper via LLM structured output and returns an EvaluationResult.
+
+    Receives a state dict with a single "paper" key (injected by Send).
+    Returns {"evaluated_papers": [EvaluationResult]} so the reducer can append it
+    to the shared list in the graph state.
+    """
+    paper = state["paper"]
+    title = paper.get("title", "Unknown")
+    url = paper.get("url", "")
+    content = paper.get("content", "")
+
+    logger.info("Evaluating: %s", title)
+
+    prompt = f"""You are a rigorous research analyst evaluating the relevance and quality of a paper or article.
+
+Title: {title}
+URL: {url}
+Content: {content}
+
+Score this paper on each criterion from 0 (lowest) to 10 (highest):
+
+1. **Novelty** — How original or groundbreaking is this work? Does it introduce genuinely new ideas, methods, or findings?
+2. **Clinical Efficacy** — What is the practical real-world impact or applicability? Could it meaningfully improve outcomes or systems?
+3. **Source Authority** — How credible is the source? Consider the publication venue, known authors, institution, or journal quality.
+4. **Trending Signal** — How much current traction does this topic have? Is it being widely discussed, cited, or replicated right now?
+
+Then compute:
+- **weighted_score**: (novelty * 0.25) + (clinical_efficacy * 0.30) + (source_authority * 0.25) + (trending_signal * 0.20)
+- **include_in_digest**: Set True if weighted_score >= 6.0 AND the paper is genuinely high quality and relevant
+- **reasoning**: A concise 1-2 sentence explanation of your overall evaluation
+
+Be objective, critical, and consistent across papers."""
+
+    result: EvaluationResult = _evaluator_llm.invoke(prompt)
+
+    # Recompute weighted_score deterministically to override any LLM approximation
+    result.weighted_score = round(
+        result.novelty_score * _WEIGHTS["novelty"]
+        + result.clinical_efficacy_score * _WEIGHTS["clinical_efficacy"]
+        + result.source_authority_score * _WEIGHTS["source_authority"]
+        + result.trending_signal_score * _WEIGHTS["trending_signal"],
+        2,
+    )
+
+    logger.info(
+        "Scored '%s': %.2f (include=%s)", title, result.weighted_score, result.include_in_digest
+    )
+    return {"evaluated_papers": [result]}

--- a/src/agent/nodes/evaluator/evaluation_schema.py
+++ b/src/agent/nodes/evaluator/evaluation_schema.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel, Field
+
+
+class EvaluationResult(BaseModel):
+    """Structured evaluation of a single research paper or article."""
+
+    title: str = Field(description="Title of the paper or article.")
+    url: str = Field(description="Source URL.")
+
+    novelty_score: float = Field(
+        ge=0, le=10,
+        description="How novel or original is this work? Does it introduce new ideas, methods, or findings? (0-10)",
+    )
+    clinical_efficacy_score: float = Field(
+        ge=0, le=10,
+        description="Practical real-world impact or applicability — could it improve outcomes or systems? (0-10)",
+    )
+    source_authority_score: float = Field(
+        ge=0, le=10,
+        description="Credibility of the source: venue, authors, institution, or publication type. (0-10)",
+    )
+    trending_signal_score: float = Field(
+        ge=0, le=10,
+        description="How much traction is this topic getting right now? Is it widely discussed or cited? (0-10)",
+    )
+
+    weighted_score: float = Field(
+        description=(
+            "Weighted composite score computed as: "
+            "(novelty * 0.25) + (clinical_efficacy * 0.30) + (source_authority * 0.25) + (trending_signal * 0.20)"
+        )
+    )
+    include_in_digest: bool = Field(
+        description="True if this paper should be included in the final digest (weighted_score >= 6.0 and genuinely high quality)."
+    )
+    reasoning: str = Field(description="Brief 1-2 sentence explanation of the evaluation.")

--- a/src/agent/nodes/researcher/prepare_candidates_node.py
+++ b/src/agent/nodes/researcher/prepare_candidates_node.py
@@ -1,0 +1,33 @@
+from src.agent.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def prepare_candidates_node(state: dict) -> dict:
+    """Fan-in / flatten step: converts accumulated research_results into a deduplicated
+    flat list of individual candidate papers, ready for parallel evaluation.
+
+    Runs once after all parallel research_node instances complete (LangGraph fan-in).
+    """
+    research_results = state.get("research_results", [])
+
+    papers: list[dict] = []
+    for entry in research_results:
+        papers.extend(entry.get("data", []))
+
+    # Deduplicate by URL, preserving order
+    seen: set[str] = set()
+    unique: list[dict] = []
+    for paper in papers:
+        url = paper.get("url", "")
+        if url and url not in seen:
+            seen.add(url)
+            unique.append(paper)
+
+    logger.info(
+        "Prepared %d unique candidate papers from %d research queries (%d duplicates removed)",
+        len(unique),
+        len(research_results),
+        len(papers) - len(unique),
+    )
+    return {"candidate_papers": unique}

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Sequence, TypedDict, List
+from typing import Annotated, Any, List, Optional, Sequence, TypedDict
 from langchain_core.messages import BaseMessage
 from langgraph.graph.message import add_messages
 import operator
@@ -8,9 +8,26 @@ from src.agent.nodes.planner.response_schema import ResearchTask
 
 class AgentState(TypedDict, total=False):
 
+    # ── Core ──────────────────────────────────────────────────────────────────
     messages: Annotated[Sequence[BaseMessage], add_messages]
     interest: str
     plan: List[ResearchTask]
 
+    # ── Research phase (fan-out / fan-in via operator.add) ────────────────────
     research_results: Annotated[List[dict], operator.add]
+
+    # ── Evaluation phase ──────────────────────────────────────────────────────
+    # Flat list of individual papers produced by prepare_candidates_node
+    candidate_papers: List[dict]
+
+    # Single paper injected per-node by the Send() fan-out in map_papers
+    paper: Optional[dict]
+
+    # Parallel evaluations appended by each evaluate_paper_node instance
+    evaluated_papers: Annotated[List[Any], operator.add]
+
+    # Final ranked digest produced by aggregator_node
+    digest: List[Any]
+
+    # ── Legacy synthesis (kept for backwards compatibility) ───────────────────
     synthesis: str

--- a/src/run.py
+++ b/src/run.py
@@ -21,15 +21,25 @@ def main():
             logger.info("Plan ready — %d tasks queued", len(event["plan"]))
 
     print("\n" + "=" * 60)
-    print("RESEARCH REPORT")
+    print("RESEARCH DIGEST")
     print("=" * 60)
 
-    synthesis = final_output.get("synthesis") if final_output else None
+    digest = final_output.get("digest") if final_output else None
 
-    if synthesis:
-        print(synthesis)
+    if digest:
+        print(f"\n{len(digest)} papers ranked for your digest:\n")
+        for rank, paper in enumerate(digest, start=1):
+            print(f"  {rank}. {paper.title}")
+            print(f"     Score : {paper.weighted_score:.2f}  "
+                  f"(N={paper.novelty_score:.1f}  "
+                  f"CE={paper.clinical_efficacy_score:.1f}  "
+                  f"SA={paper.source_authority_score:.1f}  "
+                  f"TS={paper.trending_signal_score:.1f})")
+            print(f"     URL   : {paper.url}")
+            print(f"     Why   : {paper.reasoning}")
+            print()
     else:
-        logger.warning("No synthesis produced. Raw results below.")
+        logger.warning("No digest produced. Raw research results below.")
         for entry in (final_output or {}).get("research_results", []):
             print(f"\n[{entry.get('query')}]")
             for source in entry.get("data", []):


### PR DESCRIPTION
## Summary
- Implements a Map-Reduce evaluation pipeline on top of the existing research graph
- Papers gathered by research nodes are scored in parallel by an LLM on Novelty, Clinical Efficacy, Source Authority, and Trending Signal
- An aggregator node reduces results, ranking and filtering to a final digest

## Changes
- `evaluation_schema.py` — `EvaluationResult` Pydantic model
- `evaluate_paper_node.py` — map node; scores one paper via structured LLM output
- `aggregator_node.py` — reduce node; filters `include_in_digest=True` and sorts by weighted score
- `prepare_candidates_node.py` — fan-in bridge; flattens `research_results` into deduplicated `candidate_papers`
- `state.py` — adds `candidate_papers`, `paper`, `evaluated_papers` (with `operator.add` reducer), and `digest`
- `graph.py` — rewires graph: `research_node → prepare_candidates → [map_papers Send()] → evaluate_paper_node → aggregator → END`
- `run.py` — prints ranked digest with per-paper scores